### PR TITLE
Fix missing `local_zone` in `tasklib`

### DIFF
--- a/pirate_add_default_time.py
+++ b/pirate_add_default_time.py
@@ -1,14 +1,16 @@
 #!/usr/bin/python
 from __future__ import print_function
-from datetime import time
-from tasklib import Task, local_zone
+from datetime import datetime, time
+from tasklib import Task
 
 DEFAULT_TIME = time(22,0,0)  # Your wanted default time
 
 def is_local_midnight(timestamp):
+    local_zone = datetime.now().astimezone().tzinfo
     return timestamp.astimezone(local_zone).time() == time(0,0,0)
 
 def set_default_time(timestamp):
+    local_zone = datetime.now().astimezone().tzinfo
     return timestamp.astimezone(local_zone).replace(
         hour=DEFAULT_TIME.hour,
         minute=DEFAULT_TIME.minute,


### PR DESCRIPTION
`tasklib` version 2.5.1 removed the `local_zone` from the namespace, which makes the hook fail.
I replaced the import of `local_zone` with `datetime.now().astimezone().tzinfo`.